### PR TITLE
Switch alpine from latest tag to specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make bootstrap
 COPY . .
 RUN make build
 
-FROM alpine:latest
+FROM alpine:3.9
 RUN apk --no-cache add ca-certificates
 COPY --from=workspace /go/src/github.com/testcontainers/moby-ryuk/bin/moby-ryuk /app
 CMD ["/app"]


### PR DESCRIPTION
Following details in issue #3 , I would like to switch to using specific version rather than latest tag because docker images are not actually refreshed automatically which means last build is based on alpine:3.7 which is a bit outdated. Versioning with specific tag also allows to trigger build on version change or as @bsideup suggested monitoring it with dependabot.