### PR TITLE
Add timeout when pinging Docker daemon

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,17 +24,10 @@ func main() {
 
 	cli, err := client.NewEnvClient()
 	if err == nil {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
 		_, err = cli.Ping(ctx)
-
-		cancel()
-
-		select {
-		case <-ctx.Done():
-			if ctx.Err() == context.DeadlineExceeded {
-				panic("Timed out pinging Docker daemon")
-			}
-		}
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func main() {
 
 		select {
 		case <-ctx.Done():
-			if ctx.Err() != nil {
+			if ctx.Err() == context.DeadlineExceeded {
 				panic("Timed out pinging Docker daemon")
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -23,8 +23,10 @@ func main() {
 	log.Printf("Starting on port %d...", *port)
 
 	cli, err := client.NewEnvClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	if err == nil {
-		_, err = cli.Ping(context.Background())
+		_, err = cli.Ping(ctx)
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ func main() {
 	log.Printf("Starting on port %d...", *port)
 
 	cli, err := client.NewEnvClient()
-
 	if err == nil {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		_, err = cli.Ping(ctx)

--- a/main.go
+++ b/main.go
@@ -23,11 +23,19 @@ func main() {
 	log.Printf("Starting on port %d...", *port)
 
 	cli, err := client.NewEnvClient()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
 	if err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		_, err = cli.Ping(ctx)
+
+		cancel()
+
+		select {
+		case <-ctx.Done():
+			if ctx.Err() != nil {
+				panic("Timed out pinging Docker daemon")
+			}
+		}
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ func main() {
 	cli, err := client.NewEnvClient()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
 	if err == nil {
 		_, err = cli.Ping(ctx)
 	}


### PR DESCRIPTION
This PR adds a timeout for `cli.Ping()` by using `context.WithTimeout()` to allow users to debug Testcontainer issues more easily.

I had a misconfigured `/etc/docker/daemon.json`, in which I included only `tcp://xxx` in `hosts` while omitting `unix:///var/run/docker.sock`. As a result, Ryuk is constantly stuck in `Ping()`, and Testcontainers fails with "Can not connect to Ryuk". Had there been a timeout and an error message, I might have found the problem earlier, without having to examine the Go source code.

I'm not an experienced Go programmer (started less than 24 hours ago because of this), so I'll be happy to know better ways of dealing with contexts.