### PR TITLE
Fix multi-arch build with pinned versions of buildx/QEMU images

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -23,9 +23,13 @@ jobs:
     # Setup for buildx
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
+      with: 
+        image: tonistiigi/binfmt:qemu-v6.0.0-12
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v1
+      with:
+        version: v0.6.1
 
     # Debugging information
     - name: Docker info


### PR DESCRIPTION
An apparent regression appeared in either buildkit/qemu which was causing the multi-arch build to fail.  #27 describes the problem. 

This PR pins the versions of these dependencies so that we should at least get reproduceable builds. When this PR was first created there was no working combination; however now it looks like this regression was fixed in some intermediate version of `tonistiigi/binfmt`.