### PR TITLE
Update dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN go mod download
 COPY . ./
 RUN make build
 
-FROM alpine:3.9
+FROM alpine:3.13.6
 RUN apk --no-cache add ca-certificates
 COPY --from=workspace /go/src/github.com/testcontainers/moby-ryuk/bin/moby-ryuk /app
 CMD ["/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as workspace
+FROM golang:1.13.3 as workspace
 WORKDIR /go/src/github.com/testcontainers/moby-ryuk
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.3 as workspace
+FROM golang:1.16.7 as workspace
 WORKDIR /go/src/github.com/testcontainers/moby-ryuk
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.7 as workspace
+FROM golang:1.17 as workspace
 WORKDIR /go/src/github.com/testcontainers/moby-ryuk
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build_all: vet fmt
 	done
 
 compile:
-	CGO_ENABLED=0 go build -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
+	CGO_ENABLED=0 go build -i -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
 
 run:
 	go run $(SOURCE_FOLDER)/main.go

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build_all: vet fmt
 	done
 
 compile:
-	CGO_ENABLED=0 go build -i -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
+	CGO_ENABLED=0 go build -v -ldflags '-s' -o $(BINARY_PATH) $(SOURCE_FOLDER)/
 
 run:
 	go run $(SOURCE_FOLDER)/main.go
@@ -36,4 +36,3 @@ lint:
 
 test:
 	go test $(SOURCE_FOLDER)/...
-


### PR DESCRIPTION
This is a subset of https://github.com/testcontainers/moby-ryuk/pull/28.  Upgrading alpine alone is enough to get `docker scan` to report no vulnerabilities, but upgrading go seems to work as well, so I went for it.