### PR TITLE
chore: use main as branch name in automation

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [published]
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ name: Release Drafter
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, reopened, synchronize]
 


### PR DESCRIPTION
## What does this PR do?
It uses `main` as branch name in the two GH workflows that used `master`

## Why is it important?
We are advocating from a neutral branch name, `main`.

## Related issues
- Closes #43

## Follows-up
Rename the master branch to main using GH UI.