### PR TITLE
chore(ci): only push Docker image on tags

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,25 +1,32 @@
-name: Build multi-arch Docker Image
+name: Release multi-arch Docker Image
 
 on:
-  push:
-    branches: [main]
-  pull_request:
+  release:
+    types: [published]
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+
     - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - run: go version
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Verify project
       run: make verify
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
@@ -29,12 +36,12 @@ jobs:
     - name: Buildx inspect
       run: docker buildx inspect
 
-    - name: Build image
+    - name: Build and push image
       uses: docker/build-push-action@v3
       with:
         context: .
         file: ./Dockerfile
         platforms: linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
-        push: false
-        # Use a 'temp' tag, that won't be pushed, for non-release builds
-        tags: testcontainers/ryuk:${{ github.event.release.tag_name || 'temp' }}
+        # Only push if we are publishing a release
+        push: true
+        tags: testcontainers/ryuk:${{ github.event.release.tag_name }}


### PR DESCRIPTION
## What does this PR do?
It copies the current build pipeline to a push pipeline, removing any interaction to Docker Hub from the build one.

The push pipeline will remove any scripted conditional in the pipeline to detect that the Github event was triggered by a release. This is possible because the workflow will only listen for published releases events.

## Why is it important?
Separation of concerns: we want to build on pushes and PRs, but only publish on tags. It will also increase the maintainability of the pipelines: having separate descriptors will help reviewers to identify where a change must be done.

## Follow ups
We could add snapshots to the push-to-main event. Because the tags will be stored at Docker Hub (no issue for us with the space), we could build&push the Docker image for the main branch, using the last commit as Docker tag. We could use this tag in e2e tests everywhere without needing to "locally" build Ryuk for specific purpose, just as  simple as consuming the "snapshot".
