### PR TITLE
Prevent Ryuk from removing itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,3 +9,4 @@ FROM alpine:3.13.6
 RUN apk --no-cache add ca-certificates
 COPY --from=workspace /go/src/github.com/testcontainers/moby-ryuk/bin/moby-ryuk /app
 CMD ["/app"]
+LABEL org.testcontainers.ryuk=true

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"gopkg.in/matryer/try.v1"
 )
 
+const ryukLabel = "org.testcontainers.ryuk"
+
 var (
 	port                  = flag.Int("p", 8080, "Port to bind at")
 	initialConnectTimeout = 1 * time.Minute
@@ -192,7 +194,7 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 			log.Println(err)
 		} else {
 			for _, container := range containers {
-				_, isReaper := container.Labels["org.testcontainers.ryuk"]
+				_, isReaper := container.Labels[ryukLabel]
 				if isReaper {
 					continue
 				}

--- a/main.go
+++ b/main.go
@@ -192,6 +192,11 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 			log.Println(err)
 		} else {
 			for _, container := range containers {
+				_, isReaper := container.Labels["org.testcontainers.ryuk"]
+				if isReaper {
+					continue
+				}
+
 				_ = cli.ContainerRemove(context.Background(), container.ID, types.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
 				deletedContainersMap[container.ID] = true
 			}

--- a/main.go
+++ b/main.go
@@ -194,8 +194,8 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 			log.Println(err)
 		} else {
 			for _, container := range containers {
-				_, isReaper := container.Labels[ryukLabel]
-				if isReaper {
+				value, isReaper := container.Labels[ryukLabel]
+				if isReaper && value == "true" {
 					continue
 				}
 

--- a/main_test.go
+++ b/main_test.go
@@ -154,6 +154,33 @@ func TestPrune(t *testing.T) {
 		assert.Equal(t, 0, di)
 	})
 
+	t.Run("Death note skips reaper container itself", func(t *testing.T) {
+		const label = "removable-container"
+		deathNote := &sync.Map{}
+		deathNote.Store(`{"label": {"`+label+`=true": true}}`, true)
+
+		ctx := context.Background()
+		c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				Image: "nginx:alpine",
+				Labels: map[string]string{
+					label:                     "true",
+					"org.testcontainers.ryuk": "true",
+				},
+				SkipReaper: true,
+			},
+			Started: true,
+		})
+		require.Nil(t, err)
+		require.NotNil(t, c)
+
+		dc, _, _, _ := prune(cli, deathNote)
+		assert.Equal(t, 0, dc)
+
+		err = c.Terminate(ctx)
+		require.Nil(t, err)
+	})
+
 	t.Run("Death note removing networks", func(t *testing.T) {
 		const label = "removable-network"
 		deathNote := &sync.Map{}


### PR DESCRIPTION
 - Workaround for https://github.com/testcontainers/testcontainers-go/issues/698
 - Add generic label to the ryuk image `org.testcontainers.ryuk` which enables the ryuk to detect itself and prevent deletions.