### PR TITLE
chore: add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+    - package-ecosystem: gomod
+      directory: /
+      schedule:
+        interval: monthly
+      open-pull-requests-limit: 3
+      rebase-strategy: disabled


### PR DESCRIPTION
## What does this PR do?
It adds dependabot config file, using a monthly schedule for updates

## Why is it important?
Keep dependencies up-to-date
