### PR TITLE
feat: set ryuk port using the environment variable

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func newConfig(args []string) (*config, error) {
 	fs := flag.NewFlagSet("ryuk", flag.ExitOnError)
 	fs.SetOutput(os.Stdout)
 
-	fs.IntVar(&cfg.Port, "p", 8080, "Port to bind at")
+	fs.IntVar(&cfg.Port, "p", 8080, "Deprecated: please use the "+portEnv+" environment variable to set the port to bind at")
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,9 +23,10 @@ import (
 )
 
 const (
-	connectionTimeoutEnv string = "RYUK_CONNECTION_TIMEOUT"
-	portEnv              string = "RYUK_PORT"
-	ryukLabel            string = "org.testcontainers.ryuk"
+	connectionTimeoutEnv   string = "RYUK_CONNECTION_TIMEOUT"
+	portEnv                string = "RYUK_PORT"
+	reconnectionTimeoutEnv string = "RYUK_RECONNECTION_TIMEOUT"
+	ryukLabel              string = "org.testcontainers.ryuk"
 )
 
 var (
@@ -76,6 +77,15 @@ func newConfig(args []string) (*config, error) {
 		}
 
 		cfg.Port = parsedPort
+	}
+
+	if timeout, ok := os.LookupEnv(reconnectionTimeoutEnv); ok {
+		parsedTimeout, err := time.ParseDuration(timeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse \"%s\": %s", reconnectionTimeoutEnv, err)
+		}
+
+		cfg.ReconnectionTimeout = parsedTimeout
 	}
 
 	return &cfg, nil

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -23,6 +24,7 @@ import (
 
 const (
 	connectionTimeoutEnv string = "RYUK_CONNECTION_TIMEOUT"
+	portEnv              string = "RYUK_PORT"
 	ryukLabel            string = "org.testcontainers.ryuk"
 )
 
@@ -43,6 +45,7 @@ type config struct {
 // while parsing RYUK_CONNECTION_TIMEOUT the error is returned.
 func newConfig(args []string) (*config, error) {
 	cfg := config{
+		Port:                8080,
 		ConnectionTimeout:   60 * time.Second,
 		ReconnectionTimeout: 10 * time.Second,
 	}
@@ -64,6 +67,15 @@ func newConfig(args []string) (*config, error) {
 		}
 
 		cfg.ConnectionTimeout = parsedTimeout
+	}
+
+	if port, ok := os.LookupEnv(portEnv); ok {
+		parsedPort, err := strconv.Atoi(port)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse \"%s\": %s", portEnv, err)
+		}
+
+		cfg.Port = parsedPort
 	}
 
 	return &cfg, nil

--- a/main_test.go
+++ b/main_test.go
@@ -313,7 +313,7 @@ func TestPrune(t *testing.T) {
 }
 
 func Test_newConfig(t *testing.T) {
-	t.Run("should return an error when failing to parse the environment variable", func(t *testing.T) {
+	t.Run("should return an error when failing to parse RYUK_CONNECTION_TIMEOUT environment variable", func(t *testing.T) {
 		t.Setenv(connectionTimeoutEnv, "bad_value")
 
 		config, err := newConfig([]string{})
@@ -321,12 +321,28 @@ func Test_newConfig(t *testing.T) {
 		require.Nil(t, config)
 	})
 
-	t.Run("should set connectionTimeout with the environment variable", func(t *testing.T) {
+	t.Run("should set connectionTimeout with RYUK_CONNECTION_TIMEOUT environment variable", func(t *testing.T) {
 		t.Setenv(connectionTimeoutEnv, "10s")
 
 		config, err := newConfig([]string{})
 		require.Nil(t, err)
 		assert.Equal(t, 10*time.Second, config.ConnectionTimeout)
+	})
+
+	t.Run("should return an error when failing to parse RYUK_PORT environment variable", func(t *testing.T) {
+		t.Setenv(portEnv, "bad_value")
+
+		config, err := newConfig([]string{})
+		require.NotNil(t, err)
+		require.Nil(t, config)
+	})
+
+	t.Run("should set connectionTimeout with RYUK_PORT environment variable", func(t *testing.T) {
+		t.Setenv(portEnv, "8081")
+
+		config, err := newConfig([]string{})
+		require.Nil(t, err)
+		assert.Equal(t, 8081, config.Port)
 	})
 
 	t.Run("should set port", func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -345,6 +345,22 @@ func Test_newConfig(t *testing.T) {
 		assert.Equal(t, 8081, config.Port)
 	})
 
+	t.Run("should return an error when failing to parse RYUK_RECONNECTION_TIMEOUT environment variable", func(t *testing.T) {
+		t.Setenv(reconnectionTimeoutEnv, "bad_value")
+
+		config, err := newConfig([]string{})
+		require.NotNil(t, err)
+		require.Nil(t, config)
+	})
+
+	t.Run("should set connectionTimeout with RYUK_RECONNECTION_TIMEOUT environment variable", func(t *testing.T) {
+		t.Setenv(reconnectionTimeoutEnv, "100s")
+
+		config, err := newConfig([]string{})
+		require.Nil(t, err)
+		assert.Equal(t, 100*time.Second, config.ReconnectionTimeout)
+	})
+
 	t.Run("should set port with port flag", func(t *testing.T) {
 		config, err := newConfig([]string{"-p", "3000"})
 		require.Nil(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -345,9 +345,17 @@ func Test_newConfig(t *testing.T) {
 		assert.Equal(t, 8081, config.Port)
 	})
 
-	t.Run("should set port", func(t *testing.T) {
+	t.Run("should set port with port flag", func(t *testing.T) {
 		config, err := newConfig([]string{"-p", "3000"})
 		require.Nil(t, err)
 		assert.Equal(t, 3000, config.Port)
+	})
+
+	t.Run("should set port from env with port flag and RYUK_PORT environment variable", func(t *testing.T) {
+		t.Setenv(portEnv, "8081")
+
+		config, err := newConfig([]string{"-p", "3000"})
+		require.Nil(t, err)
+		assert.Equal(t, 8081, config.Port)
 	})
 }


### PR DESCRIPTION
## What does this PR do?

It allows setting the Ryuk port from the RYUK_PORT environment variable, which takes precedence over the current port flag.

At the same time, we are adding a deprecation warning in the usage of the current port flag, to advertise of the changes. At this moment, if both are set, the environment will take precedence.

Besides that, we are also supporting setting the reconnection timeout using the RYUK_RECONNECTION_TIMEOUT env var.

## Why is it important?
Consistency across the different settings, as we introduced a way to configure Ryuk with env vars instead of with flags.


