### PR TITLE
chore: super simple verbose logs when pruning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ This project helps you to remove containers/networks/volumes/images by given fil
 - `RYUK_CONNECTION_TIMEOUT` - Environment variable that defines the timeout for Ryuk to receive the first connection (default: 60s). Value layout is described in [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation.
 - `RYUK_PORT` - Environment variable that defines the port where Ryuk will be bound to (default: 8080).
 - `RYUK_RECONNECTION_TIMEOUT` - Environment variable that defines the timeout for Ryuk to reconnect to Docker (default: 10s). Value layout is described in [time.ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation.
+- `RYUK_VERBOSE` - Environment variable that defines if Ryuk should print debug logs (default: false).

--- a/main.go
+++ b/main.go
@@ -323,11 +323,11 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		_ = try.Do(func(attempt int) (bool, error) {
 			argsClone := args.Clone()
 
-                  if verbose {
+			if verbose {
 				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
 			}
 
-      // API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
+			// API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
 			if serverVersion, err := cli.ServerVersion(context.Background()); err != nil && serverVersion.APIVersion >= "1.42" {
 				argsClone.Add("all", "true")
 			}
@@ -352,7 +352,7 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 				log.Printf("Deleting images with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
 			}
 
-      imagesPruneReport, err := cli.ImagesPrune(context.Background(), argsClone)
+			imagesPruneReport, err := cli.ImagesPrune(context.Background(), argsClone)
 			for _, image := range imagesPruneReport.ImagesDeleted {
 				if image.Untagged != "" {
 					deletedImagesMap[image.Untagged] = true

--- a/main.go
+++ b/main.go
@@ -323,7 +323,7 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		_ = try.Do(func(attempt int) (bool, error) {
 			argsClone := args.Clone()
 
-      if verbose {
+                  if verbose {
 				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
 			}
 

--- a/main.go
+++ b/main.go
@@ -27,18 +27,21 @@ const (
 	portEnv                string = "RYUK_PORT"
 	reconnectionTimeoutEnv string = "RYUK_RECONNECTION_TIMEOUT"
 	ryukLabel              string = "org.testcontainers.ryuk"
+	verboseEnv             string = "RYUK_VERBOSE"
 )
 
 var (
 	port                int
 	connectionTimeout   time.Duration
 	reconnectionTimeout time.Duration
+	verbose             bool
 )
 
 type config struct {
 	Port                int
 	ConnectionTimeout   time.Duration
 	ReconnectionTimeout time.Duration
+	Verbose             bool
 }
 
 // newConfig parses command line flags and returns a parsed config. config.timeout
@@ -49,12 +52,14 @@ func newConfig(args []string) (*config, error) {
 		Port:                8080,
 		ConnectionTimeout:   60 * time.Second,
 		ReconnectionTimeout: 10 * time.Second,
+		Verbose:             false,
 	}
 
 	fs := flag.NewFlagSet("ryuk", flag.ExitOnError)
 	fs.SetOutput(os.Stdout)
 
 	fs.IntVar(&cfg.Port, "p", 8080, "Deprecated: please use the "+portEnv+" environment variable to set the port to bind at")
+	fs.BoolVar(&cfg.Verbose, "v", false, "If the Ryuk container should be started in verbose mode. If the "+verboseEnv+" environment variable is set, this flag will be ignored.")
 
 	err := fs.Parse(args)
 	if err != nil {
@@ -88,6 +93,15 @@ func newConfig(args []string) (*config, error) {
 		cfg.ReconnectionTimeout = parsedTimeout
 	}
 
+	if verbose, ok := os.LookupEnv(verboseEnv); ok {
+		v, err := strconv.ParseBool(verbose)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse \"%s\": %s", verboseEnv, err)
+		}
+
+		cfg.Verbose = v
+	}
+
 	return &cfg, nil
 }
 
@@ -100,6 +114,7 @@ func main() {
 	port = cfg.Port
 	connectionTimeout = cfg.ConnectionTimeout
 	reconnectionTimeout = cfg.ReconnectionTimeout
+	verbose = cfg.Verbose
 
 	cli, err := client.NewClientWithOpts(client.FromEnv)
 	if err != nil {
@@ -254,7 +269,9 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 
 	deathNote.Range(func(note, _ interface{}) bool {
 		param := fmt.Sprint(note)
-		log.Printf("Deleting %s\n", param)
+		if verbose {
+			log.Printf("Deleting %s\n", param)
+		}
 
 		args, err := filters.FromJSON(param)
 		if err != nil {
@@ -262,21 +279,35 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 			return true
 		}
 
-		if containers, err := cli.ContainerList(context.Background(), types.ContainerListOptions{All: true, Filters: args}); err != nil {
+		containerListOpts := types.ContainerListOptions{All: true, Filters: args}
+		if verbose {
+			log.Printf("Listing containers with filter: %#v\n", containerListOpts)
+		}
+
+		if containers, err := cli.ContainerList(context.Background(), containerListOpts); err != nil {
 			log.Println(err)
 		} else {
+			containerRemoveOpts := types.ContainerRemoveOptions{RemoveVolumes: true, Force: true}
+
 			for _, container := range containers {
 				value, isReaper := container.Labels[ryukLabel]
 				if isReaper && value == "true" {
 					continue
 				}
 
-				_ = cli.ContainerRemove(context.Background(), container.ID, types.ContainerRemoveOptions{RemoveVolumes: true, Force: true})
+				if verbose {
+					log.Printf("Deleting containers with filter: %#v\n", containerRemoveOpts)
+				}
+				_ = cli.ContainerRemove(context.Background(), container.ID, containerRemoveOpts)
 				deletedContainersMap[container.ID] = true
 			}
 		}
 
 		_ = try.Do(func(attempt int) (bool, error) {
+			if verbose {
+				log.Printf("Deleting networks with filter: %#v. (Attempt %d/%d)\n", args, attempt, 10)
+			}
+
 			networksPruneReport, err := cli.NetworksPrune(context.Background(), args)
 			for _, networkID := range networksPruneReport.NetworksDeleted {
 				deletedNetworksMap[networkID] = true
@@ -290,6 +321,10 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		})
 
 		_ = try.Do(func(attempt int) (bool, error) {
+			if verbose {
+				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", args, attempt, 10)
+			}
+
 			volumesPruneReport, err := cli.VolumesPrune(context.Background(), args)
 			for _, volumeName := range volumesPruneReport.VolumesDeleted {
 				deletedVolumesMap[volumeName] = true
@@ -304,6 +339,11 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 
 		_ = try.Do(func(attempt int) (bool, error) {
 			args.Add("dangling", "false")
+
+			if verbose {
+				log.Printf("Deleting images with filter: %#v. (Attempt %d/%d)\n", args, attempt, 10)
+			}
+
 			imagesPruneReport, err := cli.ImagesPrune(context.Background(), args)
 			for _, image := range imagesPruneReport.ImagesDeleted {
 				if image.Untagged != "" {

--- a/main.go
+++ b/main.go
@@ -59,7 +59,6 @@ func newConfig(args []string) (*config, error) {
 	fs.SetOutput(os.Stdout)
 
 	fs.IntVar(&cfg.Port, "p", 8080, "Deprecated: please use the "+portEnv+" environment variable to set the port to bind at")
-	fs.BoolVar(&cfg.Verbose, "v", false, "If the Ryuk container should be started in verbose mode. If the "+verboseEnv+" environment variable is set, this flag will be ignored.")
 
 	err := fs.Parse(args)
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -383,12 +383,6 @@ func Test_newConfig(t *testing.T) {
 		assert.False(t, config.Verbose)
 	})
 
-	t.Run("should set verbose with verbose flag", func(t *testing.T) {
-		config, err := newConfig([]string{"-v"})
-		require.Nil(t, err)
-		assert.True(t, config.Verbose)
-	})
-
 	t.Run("should set port from env with port flag and RYUK_VERBOSE environment variable", func(t *testing.T) {
 		t.Setenv(verboseEnv, "false")
 

--- a/main_test.go
+++ b/main_test.go
@@ -369,7 +369,7 @@ func Test_newConfig(t *testing.T) {
 		require.Nil(t, config)
 	})
 
-	t.Run("should set connectionTimeout with RYUK_VERBOSE environment variable", func(t *testing.T) {
+	t.Run("should set verbose with RYUK_VERBOSE environment variable", func(t *testing.T) {
 		t.Setenv(verboseEnv, "true")
 
 		config, err := newConfig([]string{})
@@ -379,14 +379,6 @@ func Test_newConfig(t *testing.T) {
 		t.Setenv(verboseEnv, "false")
 
 		config, err = newConfig([]string{})
-		require.Nil(t, err)
-		assert.False(t, config.Verbose)
-	})
-
-	t.Run("should set port from env with port flag and RYUK_VERBOSE environment variable", func(t *testing.T) {
-		t.Setenv(verboseEnv, "false")
-
-		config, err := newConfig([]string{"-v"})
 		require.Nil(t, err)
 		assert.False(t, config.Verbose)
 	})

--- a/main_test.go
+++ b/main_test.go
@@ -361,6 +361,42 @@ func Test_newConfig(t *testing.T) {
 		assert.Equal(t, 100*time.Second, config.ReconnectionTimeout)
 	})
 
+	t.Run("should return an error when failing to parse RYUK_VERBOSE environment variable", func(t *testing.T) {
+		t.Setenv(verboseEnv, "bad_value")
+
+		config, err := newConfig([]string{})
+		require.NotNil(t, err)
+		require.Nil(t, config)
+	})
+
+	t.Run("should set connectionTimeout with RYUK_VERBOSE environment variable", func(t *testing.T) {
+		t.Setenv(verboseEnv, "true")
+
+		config, err := newConfig([]string{})
+		require.Nil(t, err)
+		assert.True(t, config.Verbose)
+
+		t.Setenv(verboseEnv, "false")
+
+		config, err = newConfig([]string{})
+		require.Nil(t, err)
+		assert.False(t, config.Verbose)
+	})
+
+	t.Run("should set verbose with verbose flag", func(t *testing.T) {
+		config, err := newConfig([]string{"-v"})
+		require.Nil(t, err)
+		assert.True(t, config.Verbose)
+	})
+
+	t.Run("should set port from env with port flag and RYUK_VERBOSE environment variable", func(t *testing.T) {
+		t.Setenv(verboseEnv, "false")
+
+		config, err := newConfig([]string{"-v"})
+		require.Nil(t, err)
+		assert.False(t, config.Verbose)
+	})
+
 	t.Run("should set port with port flag", func(t *testing.T) {
 		config, err := newConfig([]string{"-p", "3000"})
 		require.Nil(t, err)


### PR DESCRIPTION
## What does this PR do?
It supports configuring Ryuk to add verbosity when calling the Docker APIs. It can be set with the `RYUK_VERBOSE` environment variable, which accepts boolean values.

Everytime the Docker client is used to list/prune resources (containers, networks, volumes and images), a log will be produced if and only if the verbose variable is enabled.

## Why is it important?
Support debugging certain failures while accessing the Docker engine


