### PR TITLE
docs: Use tag 0.4.0 instead of latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project helps you to remove containers/networks/volumes/images by given fil
 
         $ RYUK_PORT=8080 ./bin/moby-ryuk
         $ # You can also run it with Docker
-        $ docker run -v /var/run/docker.sock:/var/run/docker.sock -e RYUK_PORT=8080 -p 8080:8080 docker.io/testcontainers/ryuk
+        $ docker run -v /var/run/docker.sock:/var/run/docker.sock -e RYUK_PORT=8080 -p 8080:8080 testcontainers/ryuk:0.4.0
 
 1. Connect via TCP:
 


### PR DESCRIPTION
## What does this PR do?

Updates the Ryuk tag in our README.md from `latest` (none) to `0.4.0`.

## Why is it important?

We do not update the latest tag to the latest version. The documented command does not work with `latest` (the configuration `RYUK_PORT` does not exist).

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->