### PR TITLE
fix: Add filter all=true to volume prune

### DIFF
--- a/main.go
+++ b/main.go
@@ -290,7 +290,14 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		})
 
 		_ = try.Do(func(attempt int) (bool, error) {
-			volumesPruneReport, err := cli.VolumesPrune(context.Background(), args)
+			argsClone := args.Clone()
+
+			// API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
+			if serverVersion, err := cli.ServerVersion(context.Background()); err != nil && serverVersion.APIVersion >= "1.42" {
+				argsClone.Add("all", "true")
+			}
+
+			volumesPruneReport, err := cli.VolumesPrune(context.Background(), argsClone)
 			for _, volumeName := range volumesPruneReport.VolumesDeleted {
 				deletedVolumesMap[volumeName] = true
 			}
@@ -303,8 +310,9 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		})
 
 		_ = try.Do(func(attempt int) (bool, error) {
-			args.Add("dangling", "false")
-			imagesPruneReport, err := cli.ImagesPrune(context.Background(), args)
+			argsClone := args.Clone()
+			argsClone.Add("dangling", "false")
+			imagesPruneReport, err := cli.ImagesPrune(context.Background(), argsClone)
 			for _, image := range imagesPruneReport.ImagesDeleted {
 				if image.Untagged != "" {
 					deletedImagesMap[image.Untagged] = true


### PR DESCRIPTION
## What does this PR do?

The pull request checks Docker's API version. If the version is equal or greater than `1.42`, it adds `all=true` to the volume prune filter.

## Why is it important?

The latest Moby release ([v23.0.0](https://github.com/moby/moby/releases/tag/v23.0.0)), introduces a breaking API change. It is not backwards compatible. I checked an older version (Docker Desktop for Mac 4.14.1). The mentioned API version requires another filter (`all=true`) to prune all volumes. Without the additional filter, only anonymous volumes (those without names) are removed.

Do you have any better idea in mind to check the API version?

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Closes #75

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->