### PR TITLE
fix: Invert the API version error check

### DIFF
--- a/main.go
+++ b/main.go
@@ -326,8 +326,8 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
 			}
 
-			// API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
-			if serverVersion, err := cli.ServerVersion(context.Background()); err != nil && serverVersion.APIVersion >= "1.42" {
+			// The API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
+			if serverVersion, err := cli.ServerVersion(context.Background()); err == nil && serverVersion.APIVersion >= "1.42" {
 				argsClone.Add("all", "true")
 			}
 

--- a/main.go
+++ b/main.go
@@ -322,13 +322,13 @@ func prune(cli *client.Client, deathNote *sync.Map) (deletedContainers int, dele
 		_ = try.Do(func(attempt int) (bool, error) {
 			argsClone := args.Clone()
 
-			if verbose {
-				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
-			}
-
 			// The API version >= v1.42 prunes only anonymous volumes: https://github.com/moby/moby/releases/tag/v23.0.0.
 			if serverVersion, err := cli.ServerVersion(context.Background()); err == nil && serverVersion.APIVersion >= "1.42" {
 				argsClone.Add("all", "true")
+			}
+
+			if verbose {
+				log.Printf("Deleting volumes with filter: %#v. (Attempt %d/%d)\n", argsClone, attempt, 10)
 			}
 
 			volumesPruneReport, err := cli.VolumesPrune(context.Background(), argsClone)


### PR DESCRIPTION
## What does this PR do?

The PR inverts the API version error check. It was `err != nil` before.

## Why is it important?

Yesterday, while tidying up after my tests, I accidentally inverted the error check. The fix is not considered for the latest API.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #75

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->