### PR TITLE
Update Ryuk tag in README to 0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project helps you to remove containers/networks/volumes/images by given fil
 
         $ RYUK_PORT=8080 ./bin/moby-ryuk
         $ # You can also run it with Docker
-        $ docker run -v /var/run/docker.sock:/var/run/docker.sock -e RYUK_PORT=8080 -p 8080:8080 testcontainers/ryuk:0.4.0
+        $ docker run -v /var/run/docker.sock:/var/run/docker.sock -e RYUK_PORT=8080 -p 8080:8080 testcontainers/ryuk:0.5.1
 
 1. Connect via TCP:
 


### PR DESCRIPTION
## What does this PR do?

Bump the Ryuk image tag in the README code snippet to `0.5.1`.

## Why is it important?

Better getting-started and debugging experience for users, that use the commands as provided in the README.