### PR TITLE
Add HEALTHCHECK to Linux Docker image.

### DIFF
--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -27,3 +27,4 @@ RUN apk --no-cache add ca-certificates
 COPY --from=build /bin/ryuk /bin/ryuk
 CMD ["/bin/ryuk"]
 LABEL org.testcontainers.ryuk=true
+HEALTHCHECK --start-period=5s --interval=2s --timeout=2s --retries=10 CMD netstat -ltn | grep -q ":8080"

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -27,4 +27,4 @@ RUN apk --no-cache add ca-certificates
 COPY --from=build /bin/ryuk /bin/ryuk
 CMD ["/bin/ryuk"]
 LABEL org.testcontainers.ryuk=true
-HEALTHCHECK --start-period=5s --interval=2s --timeout=2s --retries=10 CMD netstat -ltn | grep -q ":8080"
+HEALTHCHECK --start-period=5s --interval=2s --timeout=2s --retries=10 CMD [ "/bin/ash", "-c", "netstat -ltn | grep -q \":${RYUK_PORT:-8080}\""]

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -25,4 +25,3 @@ FROM ${BASE_IMAGE}
 COPY --from=build /bin/ryuk /bin/ryuk
 CMD ["/bin/ryuk"]
 LABEL org.testcontainers.ryuk=true
-HEALTHCHECK --start-period=5s --interval=2s --timeout=2s --retries=10 CMD netstat -ltn | grep -q ":8080"

--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -25,3 +25,4 @@ FROM ${BASE_IMAGE}
 COPY --from=build /bin/ryuk /bin/ryuk
 CMD ["/bin/ryuk"]
 LABEL org.testcontainers.ryuk=true
+HEALTHCHECK --start-period=5s --interval=2s --timeout=2s --retries=10 CMD netstat -ltn | grep -q ":8080"


### PR DESCRIPTION
## Summary

I ran across an issue using testcontainers in golang, specifically when testcontainers are used by multiple test packages in a single project.  Go builds a test binary for each package and runs them simultaneously.

Example project tree, where test binaries for packages `a`, `b`, `c`, and `d` will run simultaneously, attempting to use a testcontainer:
```
.
├── a
│   └── a_test.go
├── b
│   └── b_test.go
├── c
│   └── c_test.go
├── d
│   └── d_test.go
├── go.mod
└── go.sum
```

One of the test binaries will win the race to create the ryuk container, and it becomes present in the list of docker containers returned by the Docker API. 

**The problem is that it the ryuk container can be exposed by the Docker API before the container is ready to accept connections.**  A testcontainer client can attempt to connect to the container before it is accepting connections.

This results in error messages tests like:

```
2024/04/21 22:25:10 🔥 Reaper obtained from Docker for this test session 99998b629eea57023f49aefc9eda5406c84ce4c91d0c6005c1b8c00dcbbce0d7
2024/04/21 22:25:10 failed to start container: dial tcp 127.0.0.1:32917: connect: connection refused: Connecting to Ryuk on localhost:32917 failed: connecting to reaper failed: failed to create container
```

Clone this [test case repo](https://github.com/emetsger/testcontainers-ryuk-testcase) and run `go test -count=1 -v ./...` and observe the errors.

Run `go test -count=1 -p 1 -v ./...` and tests should pass.

## Prior issues
Race conditions (and the `connection refused` error message) have been the topic of previous issues, c.f.
* https://github.com/testcontainers/testcontainers-go/issues/149
* https://github.com/testcontainers/testcontainers-go/issues/764
* https://github.com/testcontainers/testcontainers-go/pull/782
  *  PR #782 specifically addressed a race condition to _create_ the container.

But this PR addresses the situation described [here](https://github.com/testcontainers/testcontainers-go/pull/782#issuecomment-1410089319) by adding a simple healthcheck using `netstat` (already present in the alpine image).

## Future Work
Once healthcheck information is exposed by the `ryuk` container, the [lookupReaperContainer](https://github.com/testcontainers/testcontainers-go/blob/main/reaper.go#L66) func can retry until the status is healthy.

I'm not on a Windows platform, and I'm not familiar with nanoserver and whether it comes with Powershell, and whether a command like `netstat -an | Select-String 8080` will work.  This PR only adds a `HEALTHCHECK` for the linux platform.

## Unintended Consequences
Adding a healthcheck to ryuk may increase its perceived startup time.

## Example Healthcheck Output
Before healthcheck (current state, i.e. `main`):
```json
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 25660,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2024-04-22T01:27:19.276032615Z",
            "FinishedAt": "0001-01-01T00:00:00Z"
        },
```

After healthcheck (this PR):
```json
        "State": {
            "Status": "running",
            "Running": true,
            "Paused": false,
            "Restarting": false,
            "OOMKilled": false,
            "Dead": false,
            "Pid": 1703,
            "ExitCode": 0,
            "Error": "",
            "StartedAt": "2024-04-22T01:46:01.038259025Z",
            "FinishedAt": "0001-01-01T00:00:00Z",
            "Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [
                    {
                        "Start": "2024-04-22T01:46:03.039126401Z",
                        "End": "2024-04-22T01:46:03.102456526Z",
                        "ExitCode": 0,
                        "Output": ""
                    },
                    {
                        "Start": "2024-04-22T01:46:05.107285902Z",
                        "End": "2024-04-22T01:46:05.151179319Z",
                        "ExitCode": 0,
                        "Output": ""
                    },
                    {
                        "Start": "2024-04-22T01:46:07.154951153Z",
                        "End": "2024-04-22T01:46:07.243256403Z",
                        "ExitCode": 0,
                        "Output": ""
                    },
                    {
                        "Start": "2024-04-22T01:46:09.247204821Z",
                        "End": "2024-04-22T01:46:09.319083404Z",
                        "ExitCode": 0,
                        "Output": ""
                    }
                ]
            }
        },
```