### PR TITLE
Fix the manifest check

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -140,6 +140,8 @@ jobs:
 
       - name: Check multi-arch manifest
         run: |
+          cat architectures_actual.txt
           cat supported-architectures.txt | sort | uniq > architectures_expected.txt
           # we're counting the entries only, because windows os.version numbers change too frequently
-          diff $(cat architectures_expected.txt | wc -l) $(cat architectures_actual.txt | wc -l)
+          # exclude manifest entries with "unknown" architectures
+          diff <(echo "$(cat architectures_expected.txt | wc -l)") <(echo "$(cat architectures_actual.txt | grep -v unknown_unknown_ | wc -l)")


### PR DESCRIPTION
This is a follow-up to #120 

- The manifest now contains entries with "unknown" architecture. The entries aren't relevant to our check on existence of expected "linux" and "windows" entries, so we're simply ignoring "unknown" architectures.
- The diff has been fixed to use our input from stdin instead of trying to read any files.
