### PR TITLE
fix(gh-actions): depend on the right workflow

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -123,7 +123,7 @@ jobs:
   check-release:
     runs-on: ubuntu-latest
     needs:
-      - publish-multi-arch-image
+      - release
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This PR is using the right job when releasing the Ryuk project.

It was possibly wrong after #120
