### PR TITLE
fix: use Started instead of listening

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the ryuk window you'll see containers/networks/volumes deleted after 10s
 
 ```log
 time=2024-09-30T19:42:30.000+01:00 level=INFO msg=starting connection_timeout=1m0s reconnection_timeout=10s request_timeout=10s shutdown_timeout=10m0s remove_retries=10 retry_offset=-1s port=8080 verbose=false
-time=2024-09-30T19:42:30.001+01:00 level=INFO msg=Started address=[::]:8080
+time=2024-09-30T19:42:30.001+01:00 level=INFO msg="Started client processing"
 time=2024-09-30T19:42:30.001+01:00 level=INFO msg="client processing started"
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="client connected" address=127.0.0.1:56432 clients=1
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="adding filter" type=label values="[testing=true testing.sessionid=mysession]"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the ryuk window you'll see containers/networks/volumes deleted after 10s
 
 ```log
 time=2024-09-30T19:42:30.000+01:00 level=INFO msg=starting connection_timeout=1m0s reconnection_timeout=10s request_timeout=10s shutdown_timeout=10m0s remove_retries=10 retry_offset=-1s port=8080 verbose=false
-time=2024-09-30T19:42:30.001+01:00 level=INFO msg=listening address=[::]:8080
+time=2024-09-30T19:42:30.001+01:00 level=INFO msg=Started address=[::]:8080
 time=2024-09-30T19:42:30.001+01:00 level=INFO msg="client processing started"
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="client connected" address=127.0.0.1:56432 clients=1
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="adding filter" type=label values="[testing=true testing.sessionid=mysession]"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the ryuk window you'll see containers/networks/volumes deleted after 10s
 
 ```log
 time=2024-09-30T19:42:30.000+01:00 level=INFO msg=starting connection_timeout=1m0s reconnection_timeout=10s request_timeout=10s shutdown_timeout=10m0s remove_retries=10 retry_offset=-1s port=8080 verbose=false
-time=2024-09-30T19:42:30.001+01:00 level=INFO msg="Started client processing"
+time=2024-09-30T19:42:30.001+01:00 level=INFO msg="Started"
 time=2024-09-30T19:42:30.001+01:00 level=INFO msg="client processing started"
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="client connected" address=127.0.0.1:56432 clients=1
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="adding filter" type=label values="[testing=true testing.sessionid=mysession]"

--- a/reaper.go
+++ b/reaper.go
@@ -140,7 +140,9 @@ func newReaper(ctx context.Context, options ...reaperOption) (*reaper, error) {
 		return nil, fmt.Errorf("listen: %w", err)
 	}
 
-	r.logger.Info("Started", fieldAddress, r.listener.Addr().String())
+	// This log message, in uppercase, is in use in different Testcontainers libraries,
+	// so it is important to keep it as is to not break the current behavior of the libraries.
+	r.logger.Info("Started client processing")
 
 	return r, nil
 }

--- a/reaper.go
+++ b/reaper.go
@@ -142,7 +142,7 @@ func newReaper(ctx context.Context, options ...reaperOption) (*reaper, error) {
 
 	// This log message, in uppercase, is in use in different Testcontainers libraries,
 	// so it is important to keep it as is to not break the current behavior of the libraries.
-	r.logger.Info("Started client processing")
+	r.logger.Info("Started", fieldAddress, r.listener.Addr().String())
 
 	return r, nil
 }

--- a/reaper.go
+++ b/reaper.go
@@ -140,7 +140,7 @@ func newReaper(ctx context.Context, options ...reaperOption) (*reaper, error) {
 		return nil, fmt.Errorf("listen: %w", err)
 	}
 
-	r.logger.Info("listening", fieldAddress, r.listener.Addr().String())
+	r.logger.Info("Started", fieldAddress, r.listener.Addr().String())
 
 	return r, nil
 }

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -280,7 +280,7 @@ func testReaperRun(t *testing.T, tc *runTest) (string, error) {
 
 	// Standard checks for basic functionality.
 	log := buf.String()
-	require.Contains(t, log, "Started client processing")
+	require.Contains(t, log, "Started")
 	require.Contains(t, log, "client connected")
 	require.Contains(t, log, "adding filter")
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -280,7 +280,7 @@ func testReaperRun(t *testing.T, tc *runTest) (string, error) {
 
 	// Standard checks for basic functionality.
 	log := buf.String()
-	require.Contains(t, log, "listening address="+addr)
+	require.Contains(t, log, "Started address="+addr)
 	require.Contains(t, log, "client connected")
 	require.Contains(t, log, "adding filter")
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -280,7 +280,7 @@ func testReaperRun(t *testing.T, tc *runTest) (string, error) {
 
 	// Standard checks for basic functionality.
 	log := buf.String()
-	require.Contains(t, log, "Started address="+addr)
+	require.Contains(t, log, "Started client processing")
 	require.Contains(t, log, "client connected")
 	require.Contains(t, log, "adding filter")
 


### PR DESCRIPTION
## What does this PR do?
It uses `Started` instead of `listening` in the log to define that Ryuk properly initialised.

## Why is this important?
To avoid breaking existing clients of Ryuk, which could be updating the Ryuk version in the properties file

## Related issues
- Relates https://github.com/testcontainers/testcontainers-java/issues/9369

## Follow-up questions
I wonder what are the different use cases to have a different ryuk version at the properties level and not use the one provided by the library.

I acknowledge that we introduced a breaking change when we updated the log format to a more structured one, which we are fixing in this PR, but if the user puts a wrong version in the properties, like a very outdated ryuk version, what can we do in that case?
