### PR TITLE
fix: multiple filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ printf "label=something_else" | nc -N localhost 8080
 In the ryuk window you'll see containers/networks/volumes deleted after 10s
 
 ```log
-time=2024-09-30T19:42:30.000+01:00 level=INFO msg=starting connection_timeout=1m0s reconnection_timeout=10s request_timeout=10s shutdown_timeout=10m0s remove_retries=10 retry_offset=-1s port=8080 verbose=false
+time=2024-09-30T19:42:30.000+01:00 level=INFO msg=starting connection_timeout=1m0s reconnection_timeout=10s request_timeout=10s shutdown_timeout=10m0s remove_retries=10 retry_offset=-1s changes_retry_interval=1s port=8080 verbose=false
 time=2024-09-30T19:42:30.001+01:00 level=INFO msg="Started"
 time=2024-09-30T19:42:30.001+01:00 level=INFO msg="client processing started"
 time=2024-09-30T19:42:38.002+01:00 level=INFO msg="client connected" address=127.0.0.1:56432 clients=1
@@ -68,13 +68,14 @@ time=2024-09-30T19:42:52.216+01:00 level=INFO msg=done
 
 The following environment variables can be configured to change the behaviour:
 
-| Environment Variable        | Default | Format  | Description  |
-| --------------------------- | ------- | ------- | ------------ |
-| `RYUK_CONNECTION_TIMEOUT`   | `60s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration without receiving any connections which will trigger a shutdown |
-| `RYUK_PORT`                 | `8080`  | `uint16` | The port to listen on for connections |
-| `RYUK_RECONNECTION_TIMEOUT` | `10s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration after the last connection closes which will trigger resource clean up and shutdown |
-| `RYUK_REQUEST_TIMEOUT`      | `10s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The timeout for any Docker requests |
-| `RYUK_REMOVE_RETRIES`       | `10`    | `int` | The number of times to retry removing a resource |
-| `RYUK_RETRY_OFFSET`         | `-1s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The offset added to the start time of the prune pass that is used as the minimum resource creation time. Any resource created after this calculated time will trigger a retry to ensure in use resources are not removed |
-| `RYUK_VERBOSE`              | `false` | `bool` | Whether to enable verbose aka debug logging |
-| `RYUK_SHUTDOWN_TIMEOUT`     | `10m`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration after shutdown has been requested when the remaining connections are ignored and prune checks start |
+| Environment Variable          | Default | Format  | Description  |
+| ----------------------------- | ------- | ------- | ------------ |
+| `RYUK_CONNECTION_TIMEOUT`     | `60s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration without receiving any connections which will trigger a shutdown |
+| `RYUK_PORT`                   | `8080`  | `uint16` | The port to listen on for connections |
+| `RYUK_RECONNECTION_TIMEOUT`   | `10s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration after the last connection closes which will trigger resource clean up and shutdown |
+| `RYUK_REQUEST_TIMEOUT`        | `10s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The timeout for any Docker requests |
+| `RYUK_REMOVE_RETRIES`         | `10`    | `int` | The number of times to retry removing a resource |
+| `RYUK_RETRY_OFFSET`           | `-1s`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The offset added to the start time of the prune pass that is used as the minimum resource creation time. Any resource created after this calculated time will trigger a retry to ensure in use resources are not removed |
+| `RYUK_CHANGES_RETRY_INTERVAL` | `1s`    | [Duration](https://golang.org/pkg/time/#ParseDuration) | The internal between retries if resource changes (containers, networks, images, and volumes) are detected while pruning |
+| `RYUK_VERBOSE`                | `false` | `bool` | Whether to enable verbose aka debug logging |
+| `RYUK_SHUTDOWN_TIMEOUT`       | `10m`   | [Duration](https://golang.org/pkg/time/#ParseDuration) | The duration after shutdown has been requested when the remaining connections are ignored and prune checks start |

--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type config struct {
 	// calculated time will trigger a retry to ensure in use resources are not removed.
 	RetryOffset time.Duration `env:"RYUK_RETRY_OFFSET" envDefault:"-1s"`
 
+	// ChangesRetryInterval is the internal between retries if resource changes (containers,
+	// networks, images, and volumes) are detected while pruning.
+	ChangesRetryInterval time.Duration `env:"RYUK_CHANGES_RETRY_INTERVAL" envDefault:"1s"`
+
 	// ShutdownTimeout is the maximum amount of time the reaper will wait
 	// for once signalled to shutdown before it terminates even if connections
 	// are still established.
@@ -49,6 +53,7 @@ func (c config) LogAttrs() []slog.Attr {
 		slog.Duration("shutdown_timeout", c.ShutdownTimeout),
 		slog.Int("remove_retries", c.RemoveRetries),
 		slog.Duration("retry_offset", c.RetryOffset),
+		slog.Duration("changes_retry_interval", c.ChangesRetryInterval),
 		slog.Int("port", int(c.Port)),
 		slog.Bool("verbose", c.Verbose),
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -30,13 +30,14 @@ func Test_loadConfig(t *testing.T) {
 
 	t.Run("defaults", func(t *testing.T) {
 		expected := config{
-			Port:                8080,
-			ConnectionTimeout:   time.Minute,
-			ReconnectionTimeout: time.Second * 10,
-			ShutdownTimeout:     time.Minute * 10,
-			RemoveRetries:       10,
-			RequestTimeout:      time.Second * 10,
-			RetryOffset:         -time.Second,
+			Port:                 8080,
+			ConnectionTimeout:    time.Minute,
+			ReconnectionTimeout:  time.Second * 10,
+			ShutdownTimeout:      time.Minute * 10,
+			RemoveRetries:        10,
+			RequestTimeout:       time.Second * 10,
+			RetryOffset:          -time.Second,
+			ChangesRetryInterval: time.Second,
 		}
 
 		cfg, err := loadConfig()
@@ -53,16 +54,18 @@ func Test_loadConfig(t *testing.T) {
 		t.Setenv("RYUK_REQUEST_TIMEOUT", "4s")
 		t.Setenv("RYUK_REMOVE_RETRIES", "5")
 		t.Setenv("RYUK_RETRY_OFFSET", "-6s")
+		t.Setenv("RYUK_CHANGES_RETRY_INTERVAL", "8s")
 
 		expected := config{
-			Port:                1234,
-			ConnectionTimeout:   time.Second * 2,
-			ReconnectionTimeout: time.Second * 3,
-			ShutdownTimeout:     time.Second * 7,
-			Verbose:             true,
-			RemoveRetries:       5,
-			RequestTimeout:      time.Second * 4,
-			RetryOffset:         -time.Second * 6,
+			Port:                 1234,
+			ConnectionTimeout:    time.Second * 2,
+			ReconnectionTimeout:  time.Second * 3,
+			ShutdownTimeout:      time.Second * 7,
+			Verbose:              true,
+			RemoveRetries:        5,
+			RequestTimeout:       time.Second * 4,
+			RetryOffset:          -time.Second * 6,
+			ChangesRetryInterval: time.Second * 8,
 		}
 
 		cfg, err := loadConfig()

--- a/testdata/Dockerfile
+++ b/testdata/Dockerfile
@@ -1,1 +1,3 @@
 FROM scratch
+ARG arg1
+WORKDIR ${arg1}}


### PR DESCRIPTION
Fix multiple filters which was only applying the removal of the last iterated set.

Add tests to validate that:
* Multiple filters are correctly processed
* Duplicate filters are correctly ignored
* Immediate shutdown occurs if no clients
    
This increasing code coverage to 89.4%.

Use best effort in removal if resource changes are detected after a shutdown has been signalled to allow as much to be cleaned up as possible.

This includes a new setting `ChangesRetryInterval` exposed by the env variable `RYUK_CHANGES_RETRY_INTERVAL` and defaults to 1 second which is used to control the interval between retries if resource changes are detected.