### PR TITLE
fix: run mod download with ContainerAdministrator

### DIFF
--- a/windows/Dockerfile
+++ b/windows/Dockerfile
@@ -9,9 +9,15 @@ ENV CGO_ENABLED=0
 
 WORKDIR /app
 
+# Switch to admin user for module operations
+USER ContainerAdministrator
+
 # Install source deps
 COPY go.mod go.sum ./
 RUN go mod download
+
+# Switch back to regular user for security
+USER ContainerUser
 
 # Copy source & build
 COPY . .


### PR DESCRIPTION
Recent merges have failed the Windows build with this error:

> go: updating go.mod: open C:\app\go.mod: Access is denied.

After a quick research, we considered that it could be caused by the ContainerUser not having permissions to run that command. After verifying that the ContainerAdministrator user exists with administrative privileges (see https://hub.docker.com/layers/library/golang/1.23-nanoserver/images/sha256-0ee04e227947f7b6edd033eac8b48be8279aadb75ebc9fc8d36952e99eecaa9b), we are using that user to run the mod download.


