### PR TITLE
Up golang and fix linter issues

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -13,9 +13,7 @@ import (
 func clearConfigEnv(t *testing.T) {
 	t.Helper()
 
-	var cfg config
-
-	typ := reflect.TypeOf(cfg)
+	typ := reflect.TypeFor[config]()
 	for i := range typ.NumField() {
 		field := typ.Field(i)
 		if name := field.Tag.Get("env"); name != "" {

--- a/linux/Dockerfile
+++ b/linux/Dockerfile
@@ -1,7 +1,7 @@
 # -----------
 # Build Image
 # -----------
-FROM golang:1.23-alpine3.22 AS build
+FROM golang:1.26-alpine3.22 AS build
 
 WORKDIR /app
 

--- a/reaper_test.go
+++ b/reaper_test.go
@@ -733,6 +733,7 @@ func TestReapContainer(t *testing.T) {
 	cli := testClient(t)
 
 	ids := make([]string, 2)
+
 	for i, labels := range []map[string]string{testLabels1, testLabels2} {
 		config := &container.Config{
 			Image:  testImage,
@@ -788,6 +789,7 @@ func TestReapNetwork(t *testing.T) {
 	cli := testClient(t)
 
 	ids := make([]string, 2)
+
 	for i, labels := range []map[string]string{testLabels1, testLabels2} {
 		resp, err := cli.NetworkCreate(ctx, testID(), network.CreateOptions{
 			Labels: labels,
@@ -819,6 +821,7 @@ func TestReapVolume(t *testing.T) {
 	cli := testClient(t)
 
 	ids := make([]string, 2)
+
 	for i, labels := range []map[string]string{testLabels1, testLabels2} {
 		resp, err := cli.VolumeCreate(ctx, volume.CreateOptions{
 			Labels: labels,
@@ -850,6 +853,7 @@ func TestReapImage(t *testing.T) {
 	cli := testClient(t)
 
 	ids := make([]string, 2)
+
 	for i, labels := range []map[string]string{testLabels1, testLabels2} {
 		context, err := archive.Tar("testdata", archive.Uncompressed)
 		require.NoError(t, err)


### PR DESCRIPTION
- Updated base docker image to use Go 1.26 to fix security issues, such as CVE-2025-68121, CVE-2025-47906
- Fix golangci-lint issues